### PR TITLE
feat/recv intervals

### DIFF
--- a/src/execution.rs
+++ b/src/execution.rs
@@ -96,7 +96,8 @@ struct EventRecv {
     from:             Option<KeyActor>,
     to:               Option<KeyDummy>,
     fqn:              Arc<str>,
-    timeout:          Option<Duration>,
+    after:            Duration,
+    before:           Option<Duration>,
     payload_matchers: Vec<DstPattern>,
 }
 

--- a/src/execution/build.rs
+++ b/src/execution/build.rs
@@ -506,7 +506,7 @@ impl Builder {
                         also_match_data,
                         from,
                         to,
-                        timeout,
+                        before: timeout,
                         no_extra: _,
                     } = def_recv;
 

--- a/src/execution/build.rs
+++ b/src/execution/build.rs
@@ -506,7 +506,8 @@ impl Builder {
                         also_match_data,
                         from,
                         to,
-                        before: timeout,
+                        before,
+                        after,
                         no_extra: _,
                     } = def_recv;
 
@@ -532,7 +533,8 @@ impl Builder {
                             .into_iter()
                             .chain(also_match_data.into_iter().cloned())
                             .collect(),
-                        timeout:          *timeout,
+                        after:            *after,
+                        before:           *before,
                         scope_key:        this_scope_key,
                     });
                     let ek_recv = EventKey::Recv(key);

--- a/src/execution/display.rs
+++ b/src/execution/display.rs
@@ -322,6 +322,10 @@ impl<'a> fmt::Display for DisplayRecordKind<'a> {
                 write!(f, "expected directed to {:?}, got routed", name)
             },
 
+            ValidFrom(r::ValidFrom(i)) => write!(f, "valid from {:?}", i),
+
+            TooEarly(r::TooEarly(d)) => write!(f, "\x1b[31mtoo early\x1b[0m ({:?} till okay)", d),
+
             Root => write!(f, "ROOT"),
             Error(r::Error { reason }) => write!(f, "{}", reason),
             // _fix_me => write!(f, "TODO"),

--- a/src/execution/runner.rs
+++ b/src/execution/runner.rs
@@ -105,7 +105,8 @@ struct Delays {
 
 #[derive(Default)]
 struct Receives {
-    deadlines: BTreeSet<(Instant, KeyRecv)>,
+    valid_from: SecondaryMap<KeyRecv, Instant>,
+    valid_trhu: BTreeSet<(Instant, KeyRecv)>,
 }
 
 impl Executable {
@@ -495,7 +496,8 @@ impl<'a> Runner<'a> {
                         from: match_from,
                         to: match_to,
                         payload_matchers,
-                        timeout: _,
+                        after: _,
+                        before: _,
                         scope_key,
                     } = &events.recv[recv_key];
 
@@ -567,6 +569,17 @@ impl<'a> Runner<'a> {
                         continue;
                     };
 
+                    let valid_from = self.receives.remove_by_key(recv_key);
+                    recorder.write(records::ValidFrom(valid_from));
+
+                    if let Some(too_early) = valid_from
+                        .checked_duration_since(Instant::now())
+                        .filter(|d| !d.is_zero())
+                    {
+                        recorder.write(records::TooEarly(too_early));
+                        continue;
+                    }
+
                     if let Some((actor_key, actor_addr)) = actor_address_to_store {
                         recorder.write(records::StoreActorAddress(
                             actor_key, *scope_key, actor_addr,
@@ -583,7 +596,6 @@ impl<'a> Runner<'a> {
 
                     self.envelopes.insert(recv_key, envelope);
                     self.ready_events.remove(&EventKey::Recv(recv_key));
-                    self.receives.remove_by_key(recv_key);
                     actually_fired_events.push(EventKey::Recv(recv_key));
 
                     recorder.write(records::EventFired(recv_key.into()));
@@ -868,19 +880,25 @@ impl<'a> Runner<'a> {
 
 impl Receives {
     fn insert(&mut self, now: Instant, key: KeyRecv, recv_event: &EventRecv) {
-        if let Some(timeout) = recv_event.timeout {
+        self.valid_from.insert(
+            key,
+            now.checked_add(recv_event.after)
+                .expect("exceeded the range of the Instant"),
+        );
+
+        if let Some(timeout) = recv_event.before {
             let deadline = now.checked_add(timeout).expect("oh don't be ridiculous!");
-            let new_entry = self.deadlines.insert((deadline, key));
+            let new_entry = self.valid_trhu.insert((deadline, key));
             assert!(new_entry);
         }
     }
 
     fn select_timed_out(&mut self, now: Instant) -> impl Iterator<Item = KeyRecv> + use<'_> {
         std::iter::repeat_with(move || {
-            let (deadline, _) = self.deadlines.first().copied()?;
+            let (deadline, _) = self.valid_trhu.first().copied()?;
             if deadline < now {
                 let (_, key) = self
-                    .deadlines
+                    .valid_trhu
                     .pop_first()
                     .expect("we've just seen it be there!");
                 Some(key)
@@ -891,8 +909,13 @@ impl Receives {
         .map_while(std::convert::identity)
     }
 
-    fn remove_by_key(&mut self, key: KeyRecv) {
-        self.deadlines.retain(|(_deadline, k)| *k != key);
+    fn remove_by_key(&mut self, key: KeyRecv) -> Instant {
+        let valid_from = self
+            .valid_from
+            .remove(key)
+            .expect("recv-key should have existed");
+        self.valid_trhu.retain(|(_deadline, k)| *k != key);
+        valid_from
     }
 }
 

--- a/src/recorder.rs
+++ b/src/recorder.rs
@@ -74,6 +74,8 @@ pub(crate) enum RecordKind {
     EnvelopeReceived(records::EnvelopeReceived),
     MatchingRecv(records::MatchingRecv),
     ExpectedDirectedGotRouted(records::ExpectedDirectedGotRouted),
+    ValidFrom(records::ValidFrom),
+    TooEarly(records::TooEarly),
 }
 
 impl RecordLog {

--- a/src/recorder/records.rs
+++ b/src/recorder/records.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use elfo::Addr;
 use serde_json::Value;
+use tokio::time::Instant;
 
 use crate::execution::runner::ReadyEventKey;
 use crate::execution::{
@@ -89,3 +91,9 @@ pub(crate) struct MatchingRecv(pub KeyRecv);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ExpectedDirectedGotRouted(pub KeyDummy);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ValidFrom(pub Instant);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TooEarly(pub Duration);

--- a/src/scenario.rs
+++ b/src/scenario.rs
@@ -125,7 +125,8 @@ pub struct DefEventRecv {
     #[serde(with = "humantime_serde")]
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
-    pub timeout: Option<Duration>,
+    #[serde(alias = "timeout")]
+    pub before: Option<Duration>,
 
     #[serde(flatten)]
     pub no_extra: NoExtra,

--- a/src/scenario.rs
+++ b/src/scenario.rs
@@ -128,6 +128,11 @@ pub struct DefEventRecv {
     #[serde(alias = "timeout")]
     pub before: Option<Duration>,
 
+    #[serde(with = "humantime_serde")]
+    #[serde(skip_serializing_if = "Duration::is_zero")]
+    #[serde(default)]
+    pub after: Duration,
+
     #[serde(flatten)]
     pub no_extra: NoExtra,
 }


### PR DESCRIPTION
- **recv.timeout -> recv.before(alias=timeout)**
- **feat: `recv.{after,before}` support**
